### PR TITLE
Fix Zotero plugin release workflow missing tag_name

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -205,6 +205,7 @@ jobs:
         if: steps.check-zotero.outputs.has_zotero_package == 'true'
         uses: softprops/action-gh-release@v2
         with:
+          tag_name: ${{ steps.version.outputs.tag }}
           files: packages/zotero-plugin-uts/zotero-plugin-uts@*.xpi
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Add `tag_name` input to `softprops/action-gh-release@v2` step in `.github/workflows/release.yml`. This ensures the release is created/updated for the correct tag, as the workflow is triggered on push to main, not on tag creation.

---
*PR created automatically by Jules for task [31747901660792480](https://jules.google.com/task/31747901660792480) started by @gracefullight*